### PR TITLE
fix: Replace DefaultAzureCredential with AzureCliCredential for Cloud…

### DIFF
--- a/docs/FabricDataIngestion.md
+++ b/docs/FabricDataIngestion.md
@@ -77,7 +77,7 @@ The script expects these CSV files in the data directory:
 
 ## Authentication
 
-Uses `DefaultAzureCredential` for authentication. Ensure you're authenticated via:
+Uses `AzureCliCredential` for authentication. Ensure you're authenticated via:
 - Azure CLI: `az login`
 - Managed Identity
 - Environment variables

--- a/infra/scripts/fabric/fabric_data_ingester.py
+++ b/infra/scripts/fabric/fabric_data_ingester.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 import os
-from azure.identity import DefaultAzureCredential
+from azure.identity import AzureCliCredential
 from azure.kusto.data import KustoConnectionStringBuilder, KustoClient
 from azure.kusto.data.exceptions import KustoServiceError
 from azure.kusto.ingest import QueuedIngestClient, IngestionProperties
@@ -10,7 +10,7 @@ import pandas as pd
 
 def create_kusto_client(cluster_uri: str):
     try:
-        credential = DefaultAzureCredential()
+        credential = AzureCliCredential()
         kcsb = KustoConnectionStringBuilder.with_azure_token_credential(cluster_uri, credential)
         client = KustoClient(kcsb)
         return client
@@ -23,7 +23,7 @@ def create_kusto_client(cluster_uri: str):
 def create_ingestion_client(cluster_uri: str):
     try:
         print(f"Connecting to Fabric cluster: {cluster_uri}")
-        credential = DefaultAzureCredential()
+        credential = AzureCliCredential()
         
         # Create ingestion client using the ingestion endpoint
         # The ingestion URI is typically the cluster URI with 'ingest-' prefix

--- a/infra/scripts/fabric/fabric_database.py
+++ b/infra/scripts/fabric/fabric_database.py
@@ -24,7 +24,7 @@ script_dir = Path(__file__).parent
 scripts_dir = script_dir.parent
 sys.path.insert(0, str(scripts_dir))
 
-from azure.identity import DefaultAzureCredential
+from azure.identity import AzureCliCredential
 from azure.kusto.data import KustoClient, KustoConnectionStringBuilder, ClientRequestProperties
 from azure.kusto.data.exceptions import KustoServiceError
 
@@ -45,7 +45,7 @@ def create_kusto_client(cluster_uri) -> KustoClient:
     try:
         
         print(f"Connecting to Fabric cluster: {cluster_uri}")
-        credential = DefaultAzureCredential()
+        credential = AzureCliCredential()
         kcsb = KustoConnectionStringBuilder.with_azure_token_credential(cluster_uri, credential)
         client = KustoClient(kcsb)
         print(f"✅ Connected to Fabric cluster")

--- a/infra/scripts/fabric/fabric_eventhub.py
+++ b/infra/scripts/fabric/fabric_eventhub.py
@@ -8,7 +8,7 @@ It can automatically retrieve Event Hub access keys using Azure credentials,
 or use provided keys to set up connections.
 
 Features:
-- Automatically retrieve Event Hub access keys using DefaultAzureCredential
+- Automatically retrieve Event Hub access keys using AzureCliCredential
 - Create or update Event Hub connections in Microsoft Fabric
 - Support for both hub-level and namespace-level key retrieval
 
@@ -28,14 +28,14 @@ Environment Setup:
 
 import argparse
 import sys
-from azure.identity import DefaultAzureCredential
+from azure.identity import AzureCliCredential
 from azure.mgmt.eventhub import EventHubManagementClient
 from fabric_api import FabricApiClient, FabricWorkspaceApiClient, FabricApiError
 
 
 def get_event_hub_primary_key(namespace_name: str, hub_name: str, subscription_id: str, resource_group_name: str, authorization_rule_name: str = "RootManageSharedAccessKey") -> dict:
     """
-    Get the primary access key from an Azure Event Hub using DefaultAzureCredential.
+    Get the primary access key from an Azure Event Hub using AzureCliCredential.
     
     Args:
         namespace_name: Name of the Event Hub namespace
@@ -61,7 +61,7 @@ def get_event_hub_primary_key(namespace_name: str, hub_name: str, subscription_i
         print(f"🔑 Retrieving access keys for Event Hub: {hub_name} in namespace: {namespace_name}")
         
         # Initialize Azure credential
-        credential = DefaultAzureCredential()
+        credential = AzureCliCredential()
         
         # Create Event Hub management client
         eventhub_client = EventHubManagementClient(credential, subscription_id)
@@ -117,7 +117,7 @@ def get_event_hub_namespace_primary_key(namespace_name: str, subscription_id: st
         print(f"🔑 Retrieving namespace access keys for: {namespace_name}")
         
         # Initialize Azure credential
-        credential = DefaultAzureCredential()
+        credential = AzureCliCredential()
         
         # Create Event Hub management client
         eventhub_client = EventHubManagementClient(credential, subscription_id)

--- a/src/simulator/event_hub_service.py
+++ b/src/simulator/event_hub_service.py
@@ -2,7 +2,7 @@ import json
 
 try:
     from azure.eventhub import EventHubProducerClient, EventData
-    from azure.identity import DefaultAzureCredential
+    from azure.identity import AzureCliCredential
 except ImportError:
     print("❌ Error: azure-eventhub and azure-identity packages are required.")
     print("Install them using: pip install azure-eventhub azure-identity")
@@ -12,7 +12,7 @@ class EventHubService:
     def __init__(self, fully_qualified_namespace: str, event_hub_name: str):
         self.fully_qualified_namespace = fully_qualified_namespace
         self.event_hub_name = event_hub_name
-        self.credential = DefaultAzureCredential()
+        self.credential = AzureCliCredential()
 
     def send_event(self, data: object):
         producer = EventHubProducerClient(


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Switched from DefaultAzureCredential to AzureCliCredential across all Azure SDK authentication to resolve deployment issues in Azure Cloud Shell.

Problem:
- Managed Identity not supported for Kusto endpoints in Cloud Shell
- Token acquisition failures when using DefaultAzureCredential chain
- Deployment failures in Cloud Shell environment

Solution:
- Use AzureCliCredential for explicit Azure CLI authentication
- Ensures consistent authentication method in Cloud Shell
- Works reliably with Kusto/Fabric resources

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
