### PR TITLE
fix: replace underscores with hyphens in eventstream destination names

### DIFF
--- a/infra/scripts/fabric/deploy_fabric_rti.py
+++ b/infra/scripts/fabric/deploy_fabric_rti.py
@@ -365,6 +365,10 @@ def main():
     
     print_step(11, 11, "Updating Eventstream Definition", workspace_id=workspace_id, eventstream_id=eventstream_id, eventhouse_database_name=eventhouse_database_name)
     try:
+        # Create destination-friendly names (without underscores) for eventstream
+        eventhouse_destination_name = eventhouse_name.replace('_', '-')
+        activator_destination_name = activator_name.replace('_', '-')
+        
         eventstream_definition_result = update_eventstream_definition(
             workspace_client=workspace_client,
             workspace_id=workspace_id,
@@ -375,9 +379,9 @@ def main():
             eventhouse_table_name="events",
             eventhub_connection_id=eventhub_connection_id,
             source_name=event_hub_name,
-            eventhouse_name=eventhouse_name,
+            eventhouse_name=eventhouse_destination_name,
             stream_name=eventstream_name,
-            activator_name=activator_name,
+            activator_name=activator_destination_name,
             activator_id=activator_id
         )
         if eventstream_definition_result is None:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request makes a minor update to the eventstream deployment script to ensure that destination names used for eventhouse and activator do not contain underscores, replacing them with hyphens. Underscore is an invalid character for eventstream destination names. Convert eventhouse and activator names from underscore to hyphen format when passing to eventstream definition (e.g., rti_eventhouse -> rti-eventhouse).


- Naming consistency:
  * In `deploy_fabric_rti.py`, before updating the eventstream definition, underscores in `eventhouse_name` and `activator_name` are replaced with hyphens to create `eventhouse_destination_name` and `activator_destination_name`. These new names are then used when calling `update_eventstream_definition`. [[1]](diffhunk://#diff-50b2c11e5c943dbd19de837712f07e283a67f7c06ea0701c003cfe94f4545752R368-R371) [[2]](diffhunk://#diff-50b2c11e5c943dbd19de837712f07e283a67f7c06ea0701c003cfe94f4545752L378-R384)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
