### PR TITLE
chore: added createdby and type tags for RG

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -93,11 +93,16 @@ var solutionSuffix = toLower(trim(replace(
   ''
 )))
 
+@description('Tag, Created by user name')
+param createdBy string = contains(deployer(), 'userPrincipalName')? split(deployer().userPrincipalName, '@')[0]: deployer().objectId
+
 var allTags = union(
   {
     'azd-env-name': solutionName
     TemplateName: 'Real-time Ingestion Fabric Solution Accelerator'
     SecurityControl: 'Ignore' // TODO - temp tag to override MSFT subscription controls for testing
+    CreatedBy: createdBy
+    Type: 'Non-WAF'
   },
   tags
 )


### PR DESCRIPTION
## Purpose
This pull request introduces a new parameter to tag deployed resources with the creator's username and adds two tags to all resources for improved traceability and classification.

Resource tagging improvements:

* Added a `createdBy` parameter that extracts the username from the deployer information, and included it as the `CreatedBy` tag in the `allTags` object.
* Added a `Type: 'Non-WAF'` tag to the `allTags` object for resource classification.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
