### PR TITLE
fix: Fabric Event Hub connection credentials

### DIFF
--- a/.github/workflows/azd-ai-template-validation.yml
+++ b/.github/workflows/azd-ai-template-validation.yml
@@ -18,9 +18,29 @@ jobs:
     runs-on: ubuntu-latest
     name: Validation steps
     environment: 'rti-validate'
+    env:
+      RG_TAGS: ${{ vars.RG_TAGS }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Add RG tags into Bicep parameter file
+        shell: bash
+        run: |
+          # Parse RG_TAGS (format: "Key=Value Key2=Value2") into a JSON object
+          TAG_JSON="{}"
+          for tag in ${{ env.RG_TAGS }}; do
+            KEY="${tag%%=*}"
+            VALUE="${tag#*=}"
+            TAG_JSON=$(echo "$TAG_JSON" | jq --arg k "$KEY" --arg v "$VALUE" '. + {($k): $v}')
+          done
+
+          jq --argjson tags "$TAG_JSON" '.parameters.tags = {"value": $tags}' \
+            infra/main.parameters.json > infra/main.parameters.tmp.json
+          mv infra/main.parameters.tmp.json infra/main.parameters.json
+          echo "✅ Added tags into main.parameters.json"
+          cat infra/main.parameters.json
+
       - name: Validate AZD template
         uses: microsoft/template-validation-action@Latest
         id: validation
@@ -32,5 +52,5 @@ jobs:
           AZURE_ENV_NAME: '${{ vars.AZURE_ENV_NAME }}val'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: print result
+      - name: Print result
         run: cat ${{ steps.validation.outputs.resultFile }}

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -31,6 +31,7 @@ env:
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   AZURE_LOCATION: 'westus3'
   PYTHONIOENCODING: utf-8
+  RG_TAGS: ${{ vars.RG_TAGS }}
   
 jobs:
   build:
@@ -76,7 +77,7 @@ jobs:
           rg_exists=$(az group exists --name $RESOURCE_GROUP_NAME)
           if [ "$rg_exists" = "false" ]; then
             echo "📦 Resource group does not exist. Creating new resource group '$RESOURCE_GROUP_NAME' in location '$AZURE_LOCATION'..."
-            az group create --name $RESOURCE_GROUP_NAME --location $AZURE_LOCATION || { echo "❌ Error creating resource group"; exit 1; }
+            az group create --name $RESOURCE_GROUP_NAME --location $AZURE_LOCATION --tags ${{ env.RG_TAGS }} || { echo "❌ Error creating resource group"; exit 1; }
             echo "✅ Resource group '$RESOURCE_GROUP_NAME' created successfully."
           else
             echo "✅ Resource group '$RESOURCE_GROUP_NAME' already exists. Deploying to existing resource group."

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -548,6 +548,11 @@ az login
 
 ### 4.4 Start Deployment
 
+**NOTE:** If you are running the latest azd version (version 1.23.9), please run the following command. 
+```bash 
+azd config set provision.preflight off
+```
+
 Run the deployment command:
 
 ```bash

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -97,6 +97,7 @@ var allTags = union(
   {
     'azd-env-name': solutionName
     TemplateName: 'Real-time Ingestion Fabric Solution Accelerator'
+    Type:'Non-WAF'
   },
   tags
 )

--- a/infra/scripts/fabric/fabric_api.py
+++ b/infra/scripts/fabric/fabric_api.py
@@ -86,6 +86,22 @@ class FabricApiClient:
         minutes = int(elapsed_seconds // 60)
         seconds = int(elapsed_seconds % 60)
         return f"{minutes}m {seconds}s"
+
+    @staticmethod
+    def _normalize_eventhub_endpoint(namespace_or_endpoint: str) -> str:
+        """Normalize Event Hub endpoint to the connector-expected host format.
+
+        Accepts either a bare namespace (e.g. "myns") or a full endpoint
+        (e.g. "sb://myns.servicebus.windows.net/") and returns
+        "myns.servicebus.windows.net".
+        """
+        endpoint = (namespace_or_endpoint or "").strip()
+        if endpoint.startswith("sb://"):
+            endpoint = endpoint[len("sb://"):]
+        endpoint = endpoint.rstrip("/")
+        if ".servicebus.windows.net" not in endpoint:
+            endpoint = f"{endpoint}.servicebus.windows.net"
+        return endpoint
     
     def start_long_running_operation(self,
                                    uri: str,
@@ -759,6 +775,8 @@ class FabricApiClient:
         """
         self._log(f"Creating Event Hub connection: {name}")
         
+        normalized_endpoint = self._normalize_eventhub_endpoint(namespace_name)
+
         connection_payload = {
             "displayName": name,
             "connectivityType": "ShareableCloud",
@@ -770,7 +788,7 @@ class FabricApiClient:
                     {
                         "name": "endpoint",
                         "dataType": "Text",
-                        "value": namespace_name,
+                        "value": normalized_endpoint,
                     },
                     {
                         "name": "entityPath",
@@ -780,6 +798,8 @@ class FabricApiClient:
                 ]
             },
             "credentialDetails": {
+                "singleSignOnType": "None",
+                "skipTestConnection": True,
                 "credentials": {
                     "credentialType": "Basic", # the endpoint only accepts Basic auth, but takes SAS key with policy name as password and username
                     "username": shared_access_policy_name, #"RootManageSharedAccessKey",
@@ -818,11 +838,31 @@ class FabricApiClient:
         try:
             self._log(f"Updating Event Hub connection: {name} (ID: {connection_id})")
             
+            normalized_endpoint = self._normalize_eventhub_endpoint(namespace_name)
+
             connection_payload = {
                 "displayName": name,
                 "connectivityType": "ShareableCloud",
                 "allowConnectionUsageInGateway": False,
+                "connectionDetails": {
+                    "type": "EventHub",
+                    "creationMethod": "EventHub.Contents",
+                    "parameters": [
+                        {
+                            "name": "endpoint",
+                            "dataType": "Text",
+                            "value": normalized_endpoint,
+                        },
+                        {
+                            "name": "entityPath",
+                            "dataType": "Text",
+                            "value": event_hub_name,
+                        }
+                    ]
+                },
                 "credentialDetails": {
+                    "singleSignOnType": "None",
+                    "skipTestConnection": True,
                     "credentials": {
                         "credentialType": "Basic", # the endpoint only accepts Basic auth, but takes SAS key with policy name as password and username
                         "username": shared_access_policy_name,


### PR DESCRIPTION
## Summary
- normalize Event Hub endpoint to fully qualified host format
- include connectionDetails in Event Hub update payload
- set credentialDetails.singleSignOnType to None and skipTestConnection to true

## Why
Deployment failed in Fabric connection creation with IncorrectCredentials during postprovision step.

## Validation
- local file diagnostics for infra/scripts/fabric/fabric_api.py show no errors