### PR TITLE
fix: add SecurityControl Ignore tag to Event Hub namespace to allow local auth

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -102,6 +102,10 @@ var allTags = union(
   tags
 )
 
+var eventHubTags = union(allTags, {
+  SecurityControl: 'Ignore' // Required to override MSFT subscription policy controls that enforce disableLocalAuth; local auth needed for Fabric SAS connection
+})
+
 resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
   name: 'default'
   properties: {
@@ -142,6 +146,7 @@ module eventHubNamespaceModule 'br/public:avm/res/event-hub/namespace:0.13.0' = 
     skuName: 'Standard'
     skuCapacity: 1
     disableLocalAuth: false // NOTE: local auth is currently needed in order to create connection with Fabric via SAS token
+    tags: eventHubTags
     eventhubs: [
       {
         name: eventHubName


### PR DESCRIPTION
## Problem
Azure subscription policy enforces disableLocalAuth on Event Hub namespaces. This was blocking the Fabric SAS connection in the postprovision hook (same root cause as PR #58 failure).

## Changes
- Added \SecurityControl: 'Ignore'\ tag via new \ventHubTags\ variable to override the subscription policy
- Pass \ventHubTags\ to the Event Hub namespace module so the tag is applied at the resource level
- \disableLocalAuth: false\ was already in place; this tag ensures policy does not override it

## Validation
- Follows the same pattern as commit 75f87e4 which previously had this tag before it was removed in 90c0001