### PR TITLE
fix: Wire tags parameter in main.parameters.json for SFI policy bypass

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -10,6 +10,9 @@
     },
     "existingFabricCapacityName": {
       "value": "${EXISTING_FABRIC_CAPACITY_NAME}"
+    },
+    "tags": {
+      "value": "${AZURE_TAGS}"
     }
   }
 }


### PR DESCRIPTION
Wire the existing tags parameter from main.bicep into main.parameters.json so that custom tags (e.g. Securitycontrol:Ignore for SFI policy) can be passed via azd env set AZURE_TAGS.