### PR TITLE
fix: removed the bicep parameter

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -6,7 +6,6 @@ metadata:
 
 requiredVersions:
   azd: ">= 1.19.0 != 1.23.9"
-  bicep: '>= 0.33.0'
 
 hooks:
   postprovision:


### PR DESCRIPTION
## Purpose
Removed `bicep: '>= 0.33.0'` from the `requiredVersions` section in `azure.yaml`.

Related work items: AB#40862

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How to Test
* Get the code

```ngit clone https://github.com/microsoft/real-time-intelligence-operations-solution-accelerator.git
cd real-time-intelligence-operations-solution-accelerator
git checkout feature/remove-bicep-version
```n
* Test the code
  - Verify `azure.yaml` no longer contains the `bicep` version requirement

## What to Check
Verify that the following are valid
* `azure.yaml` deploys successfully without the bicep version constraint

## Other Information
- Related to ADO User Story #40862
