### PR TITLE
fix: Update resource group tags and event hub namespace module versions

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -106,10 +106,10 @@ var eventHubTags = union(allTags, {
   SecurityControl: 'Ignore' // Required to override MSFT subscription policy controls that enforce disableLocalAuth; local auth needed for Fabric SAS connection
 })
 
-resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
+resource resourceGroupTags 'Microsoft.Resources/tags@2023-07-01' = {
   name: 'default'
   properties: {
-    tags: union(reference(resourceGroup().id, '2021-04-01', 'Full').?tags ?? {}, allTags)
+    tags: union(reference(resourceGroup().id, '2023-07-01', 'Full').?tags ?? {}, allTags)
   }
 }
 
@@ -138,7 +138,7 @@ module eventHubCrossScope 'modules/event-hub.bicep' = if (useExistingEventHubNam
 }
 
 // Create a new Event Hub Namespace with an Event Hub when not using an existing namespace.
-module eventHubNamespaceModule 'br/public:avm/res/event-hub/namespace:0.13.0' = if (!useExistingEventHubNamespace) {
+module eventHubNamespaceModule 'br/public:avm/res/event-hub/namespace:0.14.1' = if (!useExistingEventHubNamespace) {
   name: take('avm.res.event-hub.namespace.${eventHubNamespaceName}', 64)
   params: {
     name: eventHubNamespaceName


### PR DESCRIPTION
## Purpose
This pull request updates the Azure Bicep infrastructure configuration to use newer API versions for resource tagging and the Event Hub namespace module. These changes improve compatibility and ensure the deployment uses the latest features and fixes.

**Resource API and module version upgrades:**

* Updated the `Microsoft.Resources/tags` resource in `infra/main.bicep` to use API version `2023-07-01` instead of `2021-04-01`, and adjusted the reference call accordingly.
* Upgraded the Event Hub namespace module from version `0.13.0` to `0.14.1` in `infra/main.bicep` to leverage the latest improvements and bug fixes.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
