### PR TITLE
fix: Restrict deploy workflow to manual trigger only

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -3,25 +3,6 @@ name: CI/CD Azure - Real-Time Intelligence Operations
 # Trigger the workflow on manual dispatch
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - dev
-    paths:
-      - 'infra/**'
-      - 'src/**'
-      - 'azure.yaml'
-      - 'requirements.txt'
-      - '.github/workflows/azure-dev.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'infra/**'
-      - 'src/**'
-      - 'azure.yaml'
-      - 'requirements.txt'
-      - '.github/workflows/azure-dev.yml'
 
 # Set up permissions for deploying with secretless Azure federated credentials
 permissions:


### PR DESCRIPTION
## Summary
Removes `push` and/or `pull_request` triggers from the deploy workflow (`azure-dev.yml`). The workflow now only runs via `workflow_dispatch` (manual trigger).

## Why
The workflow runs `azd up` which provisions Azure resources. Auto-triggering on every push/PR causes unintended resource provisioning without cleanup, leading to orphaned resource groups and unnecessary costs.