### PR TITLE
chore: update CODEOWNERS handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 
 # These owners will be the default owners for everything in the repo.
 
-* @Avijit-Microsoft @Roopan-Microsoft @Prajwal-Microsoft @Vinay-Microsoft @aniaroramsft @toherman-msft @nchandhi @dgp10801
+* @Avijit-Microsoft @Roopan-Microsoft @Prajwal1-Microsoft @VinaySh-Microsoft @aniaroramsft @toherman-msft @nchandhi @dgp10801


### PR DESCRIPTION
## Purpose
* Update CODEOWNERS to replace two GitHub handles with their current accounts.
  * `@Vinay-Microsoft` -> `@VinaySh-Microsoft`
  * `@Prajwal-Microsoft` -> `@Prajwal1-Microsoft`

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## How to Test
* No functional change; metadata only. Verify CODEOWNERS parses and references active accounts.

## What to Check
* `.github/CODEOWNERS` references the correct, active accounts.

## Other Information
Handle-only update; no functional changes.