### PR TITLE
fix: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 
 # These owners will be the default owners for everything in the repo.
 
-* @Avijit-Microsoft @Roopan-Microsoft @Prajwal1-Microsoft @VinaySh-Microsoft @aniaroramsft @toherman-msft @nchandhi @dgp10801
+* @Avijit-Microsoft @Roopan-Microsoft @Prajwal-Microsoft @Vinay-Microsoft @aniaroramsft @toherman-msft @nchandhi @dgp10801

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 
 # These owners will be the default owners for everything in the repo.
 
-* @Avijit-Microsoft @Roopan-Microsoft @Prajwal-Microsoft @Vinay-Microsoft @aniaroramsft @toherman-msft @nchandhi @dgp10801
+* @Avijit-Microsoft @Roopan-Microsoft @Prajwal1-Microsoft @VinaySh-Microsoft @aniaroramsft @toherman-msft @nchandhi @dgp10801

--- a/.github/workflows/azd-ai-template-validation.yml
+++ b/.github/workflows/azd-ai-template-validation.yml
@@ -38,7 +38,7 @@ jobs:
     environment: 'rti-validate'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set timestamp
         shell: bash
@@ -62,7 +62,7 @@ jobs:
           cat infra/main.parameters.json
 
       - name: Validate AZD template
-        uses: microsoft/template-validation-action@Latest
+        uses: microsoft/template-validation-action@bae4895d0a8abd4f0d5aad68ae8647b3027f4c91 # v0.4.4
         id: validation
         env:
           AZURE_CLIENT_ID: ${{ env.AZURE_CLIENT_ID }}

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -31,10 +31,10 @@ jobs:
       ENV_NAME: ${{ steps.generate_env_name.outputs.ENV_NAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Azure CLI
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
@@ -121,17 +121,17 @@ jobs:
       ENV_NAME: ${{ needs.build.outputs.ENV_NAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       
       - name: Azure CLI login
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553 # v2
 
       - name: Azure Developer CLI login
         shell: bash
@@ -252,17 +252,17 @@ jobs:
       SOLUTION_SUFFIX: ${{ needs.deploy.outputs.SOLUTION_SUFFIX }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Azure CLI login
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553 # v2
 
       - name: Azure Developer CLI login
         shell: bash

--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
       - name: Check Broken Links in Changed Markdown Files
         id: lychee-check-pr
         if: github.event_name == 'pull_request' && steps.changed-markdown-files.outputs.any_changed == 'true'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude ^https?://
@@ -47,7 +47,7 @@ jobs:
       - name: Check Broken Links in All Markdown Files in Entire Repo (Manual Trigger)
         id: lychee-check-manual
         if: github.event_name == 'workflow_dispatch'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude ^https?://

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
       

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark Stale Issues and PRs
-        uses: actions/stale@v10
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           stale-issue-message: "This issue is stale because it has been open 180 days with no activity. Remove stale label or comment, or it will be closed in 30 days."
           stale-pr-message: "This PR is stale because it has been open 180 days with no activity. Please update or it will be closed in 30 days."
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0  # Fetch full history for accurate branch checks
       - name: Fetch All Branches
@@ -75,7 +75,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload CSV Report of Inactive Branches
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: merged-branches-report
           path: merged_branches_report.csv


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates several GitHub Actions workflows to use specific commit SHAs for action dependencies instead of version tags. This change improves security and reliability by ensuring that workflows always use a known, immutable version of each action, preventing unexpected changes due to upstream updates.

**Security and reliability improvements:**

* Updated all `actions/checkout`, `azure/login`, `Azure/setup-azd`, `actions/setup-python`, `actions/stale`, `actions/upload-artifact`, `lycheeverse/lychee-action`, and other actions in workflow files to reference specific commit SHAs instead of tags, ensuring consistent and secure action versions. [[1]](diffhunk://#diff-34683aca25c0f453ea7070354cc14bf3b46c126474af5dadc7d625bb2d3a0822L41-R41) [[2]](diffhunk://#diff-34683aca25c0f453ea7070354cc14bf3b46c126474af5dadc7d625bb2d3a0822L65-R65) [[3]](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L34-R37) [[4]](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L124-R134) [[5]](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L255-R265) [[6]](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4L19-R19) [[7]](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4L37-R37) [[8]](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4L50-R50) [[9]](diffhunk://#diff-3a8865ff9962bd48d45f69c2cc23f0151fc5d7512150713996f86cb21309944fL20-R20) [[10]](diffhunk://#diff-3fb2867e4a7c0ecbfdf0f36a3078f1689dca17453c5e0ebdd0671bb94733b5a3L24-R27) [[11]](diffhunk://#diff-7d98caa1d6d6648f3266503a806c5b7dc6214839a1a1fabd7dcaa5c54d72222eL15-R15) [[12]](diffhunk://#diff-7d98caa1d6d6648f3266503a806c5b7dc6214839a1a1fabd7dcaa5c54d72222eL27-R27) [[13]](diffhunk://#diff-7d98caa1d6d6648f3266503a806c5b7dc6214839a1a1fabd7dcaa5c54d72222eL78-R78)

No workflow logic or behavior was changed; only the way dependencies are referenced was updated.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
