### PR TITLE
fix: Add index URL for Python package dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 # Consolidated requirements for the Real-Time Intelligence Operations Solution Accelerator
 # This file contains all Python dependencies needed for deployment scripts and project functionality
 
+--index-url https://packagefeedproxy.microsoft.io/pypi/simple/
+
 # === FABRIC DEPLOYMENT SCRIPTS (infra/scripts/fabric/) ===
 # Used by: deploy_fabric_rti.py, fabric_*.py files for Microsoft Fabric configuration deployment
 azure-identity>=1.25.1                  # Authentication for Azure services (fabric_api.py, fabric_database.py, fabric_data_ingester.py, fabric_event_hub.py)


### PR DESCRIPTION
## Purpose
Adds a --index-url directive to requirements.txt so that Python package dependencies resolve through the Microsoft package feed proxy instead of the default public PyPI index.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
