### PR TITLE
fix: remove ansible-core version in requirements files

### DIFF
--- a/infra/vscode_web/endpoint-requirements.txt
+++ b/infra/vscode_web/endpoint-requirements.txt
@@ -1,3 +1,3 @@
 azure-ai-projects==1.0.0b12
 azure-identity==1.20.0
-ansible-core~=2.17.0
+ansible-core~=2.18.19

--- a/infra/vscode_web/endpoint-requirements.txt
+++ b/infra/vscode_web/endpoint-requirements.txt
@@ -1,3 +1,2 @@
 azure-ai-projects==1.0.0b12
 azure-identity==1.20.0
-ansible-core~=2.18.19

--- a/infra/vscode_web/requirements.txt
+++ b/infra/vscode_web/requirements.txt
@@ -1,3 +1,3 @@
 azure-ai-projects==1.0.0b12
 azure-identity==1.20.0
-ansible-core~=2.17.0
+ansible-core~=2.18.19

--- a/infra/vscode_web/requirements.txt
+++ b/infra/vscode_web/requirements.txt
@@ -1,3 +1,2 @@
 azure-ai-projects==1.0.0b12
 azure-identity==1.20.0
-ansible-core~=2.18.19


### PR DESCRIPTION
## Purpose
This pull request removes the dependency on `ansible-core` from both the `endpoint-requirements.txt` and `requirements.txt` files in the `infra/vscode_web` directory. This change helps streamline the project's dependencies by eliminating an unused or unnecessary package. 

Dependency cleanup:

* Removed `ansible-core` from `infra/vscode_web/endpoint-requirements.txt` to reduce dependency bloat.
* Removed `ansible-core` from `infra/vscode_web/requirements.txt` for consistency and to ensure it is not installed in any environment.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## Other Information

This pull request removes the `ansible-core` dependency from both the `endpoint-requirements.txt` and `requirements.txt` files in the `infra/vscode_web` directory. This change simplifies the dependency list and may reduce unnecessary package installations.